### PR TITLE
Bring back deprecation fix

### DIFF
--- a/tests/integration/deprecations/comma-separated-selector-test.js
+++ b/tests/integration/deprecations/comma-separated-selector-test.js
@@ -1,6 +1,7 @@
 import { module, test } from 'qunit';
 import { setupRenderingTest } from '../../helpers';
 import hbs from 'htmlbars-inline-precompile';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
 
 import { create, text, clickOnText } from 'ember-cli-page-object';
 
@@ -8,38 +9,56 @@ import require from 'require';
 if (require.has('@ember/test-helpers')) {
   const { render } = require('@ember/test-helpers');
 
-  module('Deprecation | comma separated selectors', function(hooks) {
+  module('Deprecation | comma separated selectors', function (hooks) {
     setupRenderingTest(hooks);
 
-    test('usage of comma-separated selector in the scope leads to a deprecation', async function(assert) {
+    hooks.beforeEach(function () {
+      deprecate.__calls = [];
+    });
+
+    hooks.afterEach(function () {
+      delete deprecate.__calls;
+    });
+
+    test('usage of comma-separated selector in the scope leads to a deprecation', async function (assert) {
       let page = create({
-        scope: '.A, .B'
+        scope: '.A, .B',
       });
 
       await render(hbs`<div class="B"></div>`);
 
       page.isVisible;
 
-      assert.expectDeprecation('Usage of comma separated selectors is deprecated in ember-cli-page-object');
+      assert.deepEqual(deprecate.__calls, [
+        [
+          'comma-separated-selectors',
+          'Usage of comma separated selectors is deprecated in ember-cli-page-object',
+          '1.16.0',
+          '2.0.0',
+        ],
+      ]);
     });
 
-    test('usage of comma-separated selector in the property leads to a deprecation', async function(assert) {
+    test('usage of comma-separated selector in the property leads to a deprecation', async function (assert) {
       let page = create({
-        text: text('.A, .B')
+        text: text('.A, .B'),
       });
 
       await render(hbs`<div class="A"></div>`);
 
       page.text;
 
-      assert.expectDeprecation('Usage of comma separated selectors is deprecated in ember-cli-page-object');
+      assert.deepEqual(
+        deprecate.__calls.map(([name]) => name),
+        ['comma-separated-selectors']
+      );
     });
 
-    test('usage of comma-separated selector in the property\'s custom scope leads to a deprecation', async function(assert) {
+    test("usage of comma-separated selector in the property's custom scope leads to a deprecation", async function (assert) {
       let page = create({
         text: text('.root', {
-          scope: '.A, .B'
-        })
+          scope: '.A, .B',
+        }),
       });
 
       await render(hbs`<div class="root">
@@ -48,15 +67,18 @@ if (require.has('@ember/test-helpers')) {
 
       page.text;
 
-      assert.expectDeprecation('Usage of comma separated selectors is deprecated in ember-cli-page-object');
+      assert.deepEqual(
+        deprecate.__calls.map(([name]) => name),
+        ['comma-separated-selectors']
+      );
     });
 
-    test('don\'t show deprecation when selector doesn\'t use comma-separated selectors', async function(assert) {
+    test("don't show deprecation when selector doesn't use comma-separated selectors", async function (assert) {
       let page = create({
         scope: '.root',
         propText: text('.A', {
-          scope: '.B'
-        })
+          scope: '.B',
+        }),
       });
 
       await render(hbs`<div class="root">
@@ -67,12 +89,12 @@ if (require.has('@ember/test-helpers')) {
 
       page.text;
 
-      assert.expectNoDeprecation();
+      assert.deepEqual(deprecate.__calls, []);
     });
 
-    test('don\'t show deprecation when the selector contains text with comma', async function(assert) {
+    test("don't show deprecation when the selector contains text with comma", async function (assert) {
       let page = create({
-        clickOnButton: clickOnText('button')
+        clickOnButton: clickOnText('button'),
       });
 
       await render(hbs`<fieldset>
@@ -81,7 +103,7 @@ if (require.has('@ember/test-helpers')) {
 
       page.clickOnButton('Lorem, Ipsum');
 
-      assert.expectNoDeprecation();
+      assert.deepEqual(deprecate.__calls, []);
     });
   });
 }

--- a/tests/integration/deprecations/string-properties-test.js
+++ b/tests/integration/deprecations/string-properties-test.js
@@ -1,41 +1,75 @@
 import { module, test } from 'qunit';
 import { create } from 'ember-cli-page-object';
-import require from 'require';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
 
-if (require.has('@ember/test-helpers')) {
-  module('Deprecation | string-properties', function() {
-    test('works at top-level', function(assert) {
-      this.page = create({
-        stringProp: ''
-      });
-
-      assert.expectDeprecation()
-    });
-
-    test('works for nested definitions', function(assert) {
-      this.page = create({
-        nested: {
-          stringProp: ''
-        }
-      });
-
-      assert.expectDeprecation()
-    });
-
-    test('allows scope', function(assert) {
-      this.page = create({
-        scope: ''
-      });
-
-      assert.expectNoDeprecation()
-    });
-
-    test('allows testContainer', function(assert) {
-      this.page = create({
-        testContainer: ''
-      });
-
-      assert.expectNoDeprecation()
-    });
+module('Deprecation | string-properties', function (hooks) {
+  hooks.beforeEach(function () {
+    deprecate.__calls = [];
   });
-}
+
+  hooks.afterEach(function () {
+    delete deprecate.__calls;
+  });
+
+  test('works at top-level', function (assert) {
+    this.page = create({
+      stringProp: '',
+    });
+
+    // @todo: figure out and fix double deprecations
+    assert.deepEqual(deprecate.__calls, [
+      [
+        'string-properties-on-definition',
+        'do not use string values on definitions',
+        '1.17.0',
+        '2.0.0',
+      ],
+      [
+        'string-properties-on-definition',
+        'do not use string values on definitions',
+        '1.17.0',
+        '2.0.0',
+      ],
+    ]);
+  });
+
+  test('works for nested definitions', function (assert) {
+    this.page = create({
+      nested: {
+        stringProp: '',
+      },
+    });
+
+    // @todo: figure out and fix double deprecations
+    assert.deepEqual(deprecate.__calls, [
+      [
+        'string-properties-on-definition',
+        'do not use string values on definitions',
+        '1.17.0',
+        '2.0.0',
+      ],
+      [
+        'string-properties-on-definition',
+        'do not use string values on definitions',
+        '1.17.0',
+        '2.0.0',
+      ],
+    ]);
+  });
+
+  test('allows scope', function (assert) {
+    this.page = create({
+      scope: '',
+    });
+
+    assert.deepEqual(deprecate.__calls, []);
+  });
+
+  test('allows testContainer', function (assert) {
+    this.page = create({
+      testContainer: '',
+    });
+
+    assert.deepEqual(deprecate.__calls, []);
+  });
+});

--- a/tests/integration/deprecations/test-support-test.js
+++ b/tests/integration/deprecations/test-support-test.js
@@ -1,16 +1,32 @@
 import { test, module } from 'qunit';
 import require from 'require';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
 
-module('Deprecation | test-support');
+module('Deprecation | test-support', function (hooks) {
+  hooks.beforeEach(function () {
+    deprecate.__calls = [];
+  });
 
-test('import from test-support leads to the deprecation', function(assert) {
-  // Currently addon-exports-test statically imports `dummy/tests/page-object`.
-  // That leads to pre-loading and caching of the `dummy/tests/page-object` module
-  // on the tests startup phase.Then if we tryto  access this module again
-  // w/o cleaning the cache we won't be able to catch a deprecation.
-  window.require.unsee('dummy/tests/page-object');
+  hooks.afterEach(function () {
+    delete deprecate.__calls;
+  });
 
-  require('dummy/tests/page-object');
+  test('import from test-support leads to the deprecation', function (assert) {
+    // Currently addon-exports-test statically imports `dummy/tests/page-object`.
+    // That leads to pre-loading and caching of the `dummy/tests/page-object` module
+    // on the tests startup phase.Then if we tryto  access this module again
+    // w/o cleaning the cache we won't be able to catch a deprecation.
+    window.require.unsee('dummy/tests/page-object');
 
-  assert.expectDeprecation(`Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`);
-})
+    require('dummy/tests/page-object');
+
+    assert.deepEqual(deprecate.__calls, [
+      [
+        'import-from-test-support',
+        'Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.',
+        '1.16.0',
+        '2.0.0',
+      ],
+    ]);
+  });
+});

--- a/tests/unit/-private/deprecate-test.js
+++ b/tests/unit/-private/deprecate-test.js
@@ -1,0 +1,51 @@
+import { module, test } from 'qunit';
+import deprecate from 'ember-cli-page-object/test-support/-private/deprecate';
+
+module('Unit | deprecate', function (hooks) {
+  let origWarn, calls;
+
+  hooks.beforeEach(function () {
+    origWarn = console.warn;
+
+    calls = [];
+    console.warn = (...args) => {
+      calls.push(args);
+    };
+  });
+
+  hooks.afterEach(function () {
+    console.warn = origWarn;
+  });
+
+  test('it renders', function (assert) {
+    deprecate('a-name', 'a message', '1.1', '1.2.3');
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].length, 1);
+    assert.equal(
+      calls[0][0].split('\n')[0],
+      'DEPRECATION: a message [deprecation id: ember-cli-page-object.a-name] See https://ember-cli-page-object.js.org/docs/v1.1.x/deprecations#a-name for more details.'
+    );
+  });
+
+  module('tracking', function (hooks) {
+    hooks.afterEach(function () {
+      delete deprecate.__calls;
+    });
+
+    test('disabled by default', function (assert) {
+      deprecate('a-name', 'a message', '1.1', '1.2.3');
+
+      assert.strictEqual(deprecate.__calls, undefined);
+    });
+
+    test('it works', function (assert) {
+      deprecate.__calls = [];
+      deprecate('a-name', 'a message', '1.1', '1.2.3');
+
+      assert.deepEqual(deprecate.__calls, [
+        ['a-name', 'a message', '1.1', '1.2.3'],
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
This was lost in extraction and is needed here as the assertions for
deprecations don't work with this version of Qunit.

Originally in: https://github.com/san650/ember-cli-page-object/pull/542