### PR TITLE
Fix Lint issues new in Ember 3.28

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -54,5 +54,15 @@ module.exports = {
       plugins: ['node'],
       extends: ['plugin:node/recommended'],
     },
+    // dummy app @todo update all dummy app code to octane patterns
+    {
+      files: ['tests/dummy/app/**/*.js'],
+      rules: {
+        'ember/no-classic-classes': 0,
+        'ember/no-classic-components': 0,
+        'ember/no-actions-hash': 0,
+        'ember/require-tagless-components': 0,
+      },
+    },
   ],
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,7 +20,7 @@ module.exports = {
   },
   rules: {
     'ember/no-global-jquery': 0,
-    'no-console': [ "error", { allow: [ "warn", "error" ] } ]
+    'no-console': ['error', { allow: ['warn', 'error'] }],
   },
   overrides: [
     // node files

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,5 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'recommended',
 };

--- a/addon-test-support/-private/action.js
+++ b/addon-test-support/-private/action.js
@@ -9,27 +9,27 @@ export default function action(query, cb) {
         ({ query, cb } = normalizeArgs(key, query, cb, args));
 
         return run(this, query, (executionContext) => {
-          return cb.bind(executionContext)(...args)
+          return cb.bind(executionContext)(...args);
         });
-      }
-    }
-  }
+      };
+    },
+  };
 }
 
 function normalizeArgs(key, query, cb, args) {
-  let formattedKey = `${key}(${args.length
-    ? `"${args.map((a) => String(a)).join('", "')}"`
-    : ``})`;
+  let formattedKey = `${key}(${
+    args.length ? `"${args.map((a) => String(a)).join('", "')}"` : ``
+  })`;
 
   if (typeof query === 'function') {
     cb = query;
     query = {
-      key: formattedKey
+      key: formattedKey,
     };
   } else {
     query = {
       ...query,
-      key: formattedKey
+      key: formattedKey,
     };
   }
 

--- a/addon-test-support/-private/better-errors.js
+++ b/addon-test-support/-private/better-errors.js
@@ -25,7 +25,8 @@ export function throwBetterError(node, key, error, { selector } = {}) {
   let path = [key];
   let current;
 
-  let fullErrorMessage = error instanceof Error ? error.message : error.toString();
+  let fullErrorMessage =
+    error instanceof Error ? error.message : error.toString();
 
   for (current = node; current; current = Ceibo.parent(current)) {
     path.unshift(Ceibo.meta(current).key);

--- a/addon-test-support/-private/chainable.js
+++ b/addon-test-support/-private/chainable.js
@@ -40,7 +40,7 @@ function getChildNode(node, key) {
   let match;
   if ((match = /\[(\d+)\]$/.exec(key))) {
     // This is a collection item
-    let [ indexStr, index ] = match;
+    let [indexStr, index] = match;
     let name = key.slice(0, -indexStr.length);
 
     return node[name].objectAt(parseInt(index, 10));

--- a/addon-test-support/-private/deprecate.js
+++ b/addon-test-support/-private/deprecate.js
@@ -7,5 +7,7 @@ export default function deprecate(name, message, since, until) {
 
   const [major, minor] = since.split('.');
 
-  console.warn(`DEPRECATION: ${message} [deprecation id: ${NAMESPACE}.${name}] See https://ember-cli-page-object.js.org/docs/v${major}.${minor}.x/deprecations#${name} for more details.`)
+  console.warn(
+    `DEPRECATION: ${message} [deprecation id: ${NAMESPACE}.${name}] See https://ember-cli-page-object.js.org/docs/v${major}.${minor}.x/deprecations#${name} for more details.`
+  );
 }

--- a/addon-test-support/-private/dsl.js
+++ b/addon-test-support/-private/dsl.js
@@ -20,7 +20,7 @@ const thenDescriptor = {
     const chainedRoot = root._chainedTree || root;
 
     return chainedRoot._promise.then(...arguments);
-  }
+  },
 };
 
 const dsl = {
@@ -37,7 +37,7 @@ const dsl = {
   select: fillable(),
   text: text(),
   then: thenDescriptor,
-  value: value()
+  value: value(),
 };
 
 export default dsl;

--- a/addon-test-support/-private/finders.js
+++ b/addon-test-support/-private/finders.js
@@ -1,16 +1,13 @@
-import {
-  $,
-  buildSelector,
-  findClosestValue,
-  guardMultiple
-} from './helpers';
+import { $, buildSelector, findClosestValue, guardMultiple } from './helpers';
 import { getAdapter } from '../adapters';
 import { throwBetterError, ELEMENT_NOT_FOUND } from './better-errors';
 
 function getContainer(pageObjectNode, options) {
-  return options.testContainer
-    || findClosestValue(pageObjectNode, 'testContainer')
-    || getAdapter().testContainer;
+  return (
+    options.testContainer ||
+    findClosestValue(pageObjectNode, 'testContainer') ||
+    getAdapter().testContainer
+  );
 }
 
 /**
@@ -27,12 +24,9 @@ export function findOne(pageObjectNode, targetSelector, options = {}) {
   guardMultiple(elements, selector);
 
   if (elements.length === 0) {
-    throwBetterError(
-      pageObjectNode,
-      options.pageObjectKey,
-      ELEMENT_NOT_FOUND,
-      { selector }
-    );
+    throwBetterError(pageObjectNode, options.pageObjectKey, ELEMENT_NOT_FOUND, {
+      selector,
+    });
   }
 
   return elements[0];
@@ -54,7 +48,11 @@ export function findMany(pageObjectNode, targetSelector, options = {}) {
  * @private
  * @deprecated
  */
-export function findElementWithAssert(pageObjectNode, targetSelector, options = {}) {
+export function findElementWithAssert(
+  pageObjectNode,
+  targetSelector,
+  options = {}
+) {
   const selector = buildSelector(pageObjectNode, targetSelector, options);
   const container = getContainer(pageObjectNode, options);
 
@@ -63,12 +61,9 @@ export function findElementWithAssert(pageObjectNode, targetSelector, options = 
   guardMultiple($elements, selector, options.multiple);
 
   if ($elements.length === 0) {
-    throwBetterError(
-      pageObjectNode,
-      options.pageObjectKey,
-      ELEMENT_NOT_FOUND,
-      { selector }
-    );
+    throwBetterError(pageObjectNode, options.pageObjectKey, ELEMENT_NOT_FOUND, {
+      selector,
+    });
   }
 
   return $elements;

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -235,7 +235,7 @@ export function objectHasProperty(object, pathToProp) {
     if (
       object === null ||
       object === undefined ||
-      !object.hasOwnProperty(key)
+      !Object.prototype.hasOwnProperty.call(object, key)
     ) {
       return false;
     } else {

--- a/addon-test-support/-private/helpers.js
+++ b/addon-test-support/-private/helpers.js
@@ -30,7 +30,7 @@ class Selector {
         'comma-separated-selectors',
         'Usage of comma separated selectors is deprecated in ember-cli-page-object',
         '1.16.0',
-        '2.0.0',
+        '2.0.0'
       );
     }
 
@@ -93,7 +93,9 @@ class Selector {
 
 export function guardMultiple(items, selector, supportMultiple) {
   if (items.length > 1 && !supportMultiple) {
-    throw new Error(`"${selector}" matched more than one element. If you want to select many elements, use collections instead.`);
+    throw new Error(
+      `"${selector}" matched more than one element. If you want to select many elements, use collections instead.`
+    );
   }
 }
 
@@ -141,9 +143,8 @@ export function guardMultiple(items, selector, supportMultiple) {
  * @return {string} Fully qualified selector
  */
 export function buildSelector(node, targetSelector, options) {
-  return (new Selector(node, options.scope, targetSelector, options)).toString();
+  return new Selector(node, options.scope, targetSelector, options).toString();
 }
-
 
 /**
  * @public
@@ -231,7 +232,11 @@ export function objectHasProperty(object, pathToProp) {
 
   for (let i = 0; i < pathSegments.length; i++) {
     const key = pathSegments[i];
-    if (object === null || object === undefined || !object.hasOwnProperty(key)) {
+    if (
+      object === null ||
+      object === undefined ||
+      !object.hasOwnProperty(key)
+    ) {
       return false;
     } else {
       object = object[key];
@@ -282,14 +287,16 @@ export function isPageObject(property) {
   }
 }
 
-export function getPageObjectDefinition(node){
-  if(!isPageObject(node)){
-    throw new Error('cannot get the page object definition from a node that is not a page object');
-  }else{
+export function getPageObjectDefinition(node) {
+  if (!isPageObject(node)) {
+    throw new Error(
+      'cannot get the page object definition from a node that is not a page object'
+    );
+  } else {
     return Ceibo.meta(node).__poDef__;
   }
 }
 
-export function storePageObjectDefinition(node, definition){
+export function storePageObjectDefinition(node, definition) {
   Ceibo.meta(node).__poDef__ = definition;
 }

--- a/addon-test-support/-private/run.js
+++ b/addon-test-support/-private/run.js
@@ -18,7 +18,7 @@ export function run(node, query, cb) {
   const executionContext = Object.freeze({
     query,
     node,
-    adapter
+    adapter,
   });
 
   const root = getRoot(node);
@@ -26,11 +26,12 @@ export function run(node, query, cb) {
     // Our root is already the root of the chained tree,
     // we need to wait on its promise if it has one so the
     // previous invocations can resolve before we run ours.
-    root._promise = resolve(root._promise).then(() => invokeHelper(executionContext, cb));
+    root._promise = resolve(root._promise).then(() =>
+      invokeHelper(executionContext, cb)
+    );
 
     return node;
-  }
-  else {
+  } else {
     // Store our invocation result on the chained root
     // so that chained calls can find it to wait on it.
     root._chainedTree._promise = invokeHelper(executionContext, cb);

--- a/addon-test-support/adapter.js
+++ b/addon-test-support/adapter.js
@@ -2,22 +2,22 @@ export default class Adapter {
   get testContainer() {
     throw new Error('`testContainer` is not implemented for the adater');
   }
-  visit( /* path */) {
+  visit(/* path */) {
     throw new Error('`visit` is not implemented for the adater');
   }
-  click( /* element */) {
+  click(/* element */) {
     throw new Error('`click` is not implemented for the adater');
   }
-  fillIn( /*element, content*/) {
+  fillIn(/*element, content*/) {
     throw new Error('`fillIn` is not implemented for the adater');
   }
-  triggerEvent( /*element, eventName, eventOptions*/) {
+  triggerEvent(/*element, eventName, eventOptions*/) {
     throw new Error('`triggerEvent` is not implemented for the adater');
   }
-  focus( /* element */) {
+  focus(/* element */) {
     throw new Error('`focus` is not implemented for the adater');
   }
-  blur( /* element */) {
+  blur(/* element */) {
     throw new Error('`blur` is not implemented for the adater');
   }
 }

--- a/addon-test-support/adapters/acceptance.js
+++ b/addon-test-support/adapters/acceptance.js
@@ -2,16 +2,13 @@
 /* eslint-disable ember/new-module-imports */
 const { $ } = Ember;
 
-import {
-  fillElement,
-  assertFocusable
-} from './helpers';
+import { fillElement, assertFocusable } from './helpers';
 
-import Adapter from "../adapter";
+import Adapter from '../adapter';
 
 export default class AcceptanceAdapter extends Adapter {
   get testContainer() {
-    return  '#ember-testing';
+    return '#ember-testing';
   }
 
   wait() {

--- a/addon-test-support/adapters/acceptance.js
+++ b/addon-test-support/adapters/acceptance.js
@@ -30,7 +30,7 @@ export default class AcceptanceAdapter extends Adapter {
   }
 
   fillIn(element, content) {
-    /* global focus */
+    // global focus
     focus(element);
 
     fillElement(element, content);
@@ -43,7 +43,7 @@ export default class AcceptanceAdapter extends Adapter {
   }
 
   triggerEvent(element, eventName, eventOptions) {
-    /* global triggerEvent */
+    // global triggerEvent
     triggerEvent(element, eventName, eventOptions);
 
     return this.wait();

--- a/addon-test-support/adapters/helpers.js
+++ b/addon-test-support/adapters/helpers.js
@@ -22,7 +22,9 @@ export function fillElement(selection, content) {
   if ($selection.is('[contenteditable][contenteditable!="false"]')) {
     $selection.html(content);
   } else if ($selection.is('[contenteditable="false"]')) {
-    throw new Error('Element cannot be filled because it has `contenteditable="false"`.');
+    throw new Error(
+      'Element cannot be filled because it has `contenteditable="false"`.'
+    );
   } else {
     $selection.val(content);
   }
@@ -46,8 +48,13 @@ export function assertFocusable(element) {
     error = 'disabled';
   } else if ($element.is('[contenteditable="false"]')) {
     error = 'contenteditable="false"';
-  } else if (!$element.is(':input, a[href], area[href], iframe, [contenteditable], [tabindex]')) {
-    error = 'not a link, input, form element, contenteditable, iframe, or an element with tabindex';
+  } else if (
+    !$element.is(
+      ':input, a[href], area[href], iframe, [contenteditable], [tabindex]'
+    )
+  ) {
+    error =
+      'not a link, input, form element, contenteditable, iframe, or an element with tabindex';
   }
 
   if (error) {

--- a/addon-test-support/adapters/index.js
+++ b/addon-test-support/adapters/index.js
@@ -1,4 +1,4 @@
-import Adapter from "../adapter";
+import Adapter from '../adapter';
 
 let _adapter;
 
@@ -7,7 +7,7 @@ let _adapter;
  */
 export function getAdapter() {
   if (!_adapter) {
-     throw new Error(`Adapter is required.
+    throw new Error(`Adapter is required.
 
 Please use \`setAdapter(\`, to instruct "ember-cli-page-object" about the adapter you want to use.`);
   }

--- a/addon-test-support/adapters/integration.js
+++ b/addon-test-support/adapters/integration.js
@@ -2,19 +2,16 @@
 /* eslint-disable ember/new-module-imports */
 const { $ } = Ember;
 
-import {
-  fillElement,
-  assertFocusable
-} from './helpers';
+import { fillElement, assertFocusable } from './helpers';
 import wait from 'ember-test-helpers/wait';
-import Adapter from "../adapter";
+import Adapter from '../adapter';
 
 export default class IntegrationAdapter extends Adapter {
   get testContainer() {
     // @todo: fix usage of private `_element`
-    return this.testContext && this.testContext._element ?
-      this.testContext._element :
-      '#ember-testing';
+    return this.testContext && this.testContext._element
+      ? this.testContext._element
+      : '#ember-testing';
   }
 
   wait() {

--- a/addon-test-support/adapters/native-events.js
+++ b/addon-test-support/adapters/native-events.js
@@ -3,11 +3,11 @@ import {
   triggerEvent,
   keyEvent,
   focus,
-  blur
+  blur,
 } from 'ember-native-dom-helpers';
 
 import { fillElement, assertFocusable } from './helpers';
-import Adapter from "../adapter";
+import Adapter from '../adapter';
 
 const { require } = window;
 let waitFn;
@@ -20,7 +20,9 @@ if (require.has('ember-test-helpers/wait')) {
   waitFn = (...args) => require('ember-test-helpers/wait').default(...args);
 } else {
   waitFn = () => {
-    throw new Error('ember-test-helpers or @ember/test-helpers must be installed');
+    throw new Error(
+      'ember-test-helpers or @ember/test-helpers must be installed'
+    );
   };
 }
 
@@ -29,9 +31,9 @@ const KEYBOARD_EVENT_TYPES = ['keydown', 'keypress', 'keyup'];
 export default class NativeEventsAdapter extends Adapter {
   get testContainer() {
     // @todo: fix usage of private `_element`
-    return this.testContext && this.testContext._element ?
-      this.testContext._element :
-      '#ember-testing';
+    return this.testContext && this.testContext._element
+      ? this.testContext._element
+      : '#ember-testing';
   }
 
   wait() {
@@ -45,7 +47,6 @@ export default class NativeEventsAdapter extends Adapter {
   }
 
   fillIn(element, content) {
-
     fillElement(element, content);
 
     triggerEvent(element, 'input');
@@ -58,7 +59,10 @@ export default class NativeEventsAdapter extends Adapter {
     // `keyCode` is a deprecated property.
     // @see: https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode
     // Due to this deprecation `ember-native-dom-helpers` doesn't accept `keyCode` as a `KeyboardEvent` option.
-    if (typeof eventOptions.key === 'undefined' && typeof eventOptions.keyCode !== 'undefined') {
+    if (
+      typeof eventOptions.key === 'undefined' &&
+      typeof eventOptions.keyCode !== 'undefined'
+    ) {
       eventOptions.key = eventOptions.keyCode.toString();
       delete eventOptions.keyCode;
     }

--- a/addon-test-support/adapters/rfc268.js
+++ b/addon-test-support/adapters/rfc268.js
@@ -6,9 +6,9 @@ import {
   triggerEvent,
   triggerKeyEvent,
   focus,
-  blur
+  blur,
 } from '@ember/test-helpers';
-import Adapter from "../adapter";
+import Adapter from '../adapter';
 
 export default class RFC268Adapter extends Adapter {
   get testContainer() {
@@ -28,7 +28,10 @@ export default class RFC268Adapter extends Adapter {
   }
 
   triggerEvent(element, eventName, eventOptions) {
-    if (typeof eventOptions.key !== 'undefined' || typeof eventOptions.keyCode !== 'undefined') {
+    if (
+      typeof eventOptions.key !== 'undefined' ||
+      typeof eventOptions.keyCode !== 'undefined'
+    ) {
       const key = eventOptions.key || eventOptions.keyCode;
 
       return triggerKeyEvent(element, eventName, key, eventOptions);

--- a/addon-test-support/create.js
+++ b/addon-test-support/create.js
@@ -1,6 +1,10 @@
 import Ceibo from 'ceibo';
 import deprecate from './-private/deprecate';
-import { getPageObjectDefinition, isPageObject, storePageObjectDefinition } from './-private/helpers';
+import {
+  getPageObjectDefinition,
+  isPageObject,
+  storePageObjectDefinition,
+} from './-private/helpers';
 import { visitable } from './properties/visitable';
 import dsl from './-private/dsl';
 
@@ -69,10 +73,13 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
         Object.defineProperty(blueprint, key, {
           value: {
             isDescriptor: true,
-            get
-          }
+            get,
+          },
         });
-      } else if (typeof value === 'string' && !['scope', 'testContainer'].includes(key)) {
+      } else if (
+        typeof value === 'string' &&
+        !['scope', 'testContainer'].includes(key)
+      ) {
         deprecate(
           'string-properties-on-definition',
           'do not use string values on definitions',
@@ -87,7 +94,7 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
 
   let blueprintToStore = { ...definition };
   //the _chainedTree is an implementation detail that shouldn't make it into the stored
-  if(blueprintToStore._chainedTree){
+  if (blueprintToStore._chainedTree) {
     delete blueprintToStore._chainedTree;
   }
   blueprint = {
@@ -95,12 +102,17 @@ function buildObject(node, blueprintKey, blueprint, defaultBuilder) {
     ...definition,
   };
 
-  const [ instance, blueprintToApply ] = defaultBuilder(node, blueprintKey, blueprint, defaultBuilder);
+  const [instance, blueprintToApply] = defaultBuilder(
+    node,
+    blueprintKey,
+    blueprint,
+    defaultBuilder
+  );
 
   // persist definition once we have an instance
   storePageObjectDefinition(instance, blueprintToStore);
 
-  return [ instance, blueprintToApply ];
+  return [instance, blueprintToApply];
 }
 
 /**
@@ -190,7 +202,7 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
   let url;
   let options;
 
-  if (typeof (definitionOrUrl) === 'string') {
+  if (typeof definitionOrUrl === 'string') {
     url = definitionOrUrl;
     definition = definitionOrOptions || {};
     options = optionsOrNothing || {};
@@ -210,7 +222,9 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
     // this is supposed to prevent an infinite recursion, for users who has not migrated
     // from the ModuleForComponent tests yet.
     // @todo: cover by test
-    throw new Error('"context" key is not allowed to be passed at definition root.');
+    throw new Error(
+      '"context" key is not allowed to be passed at definition root.'
+    );
   }
 
   if (typeof url === 'string') {
@@ -218,7 +232,7 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
       'create-url-argument',
       'Passing an URL argument to `create()` is deprecated',
       '1.17.0',
-      "2.0.0",
+      '2.0.0'
     );
   }
 
@@ -228,11 +242,11 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
 
   // Build the chained tree
   let chainedBuilder = {
-    object: buildObject
+    object: buildObject,
   };
   let chainedTree = Ceibo.create(definition, {
     builder: chainedBuilder,
-    ...options
+    ...options,
   });
 
   // Attach it to the root in the definition of the primary tree
@@ -241,16 +255,16 @@ export function create(definitionOrUrl, definitionOrOptions, optionsOrNothing) {
 
     get() {
       return chainedTree;
-    }
+    },
   };
 
   // Build the primary tree
   let builder = {
-    object: buildObject
+    object: buildObject,
   };
 
   return Ceibo.create(definition, {
     builder,
-    ...options
+    ...options,
   });
 }

--- a/addon-test-support/index.js
+++ b/addon-test-support/index.js
@@ -1,24 +1,45 @@
-import { create }      from './create';                   export { create };
+import { create } from './create';
+export { create };
 
-import { attribute }   from './properties/attribute';     export { attribute };
-import { blurrable }   from './properties/blurrable';     export { blurrable };
-import { clickOnText } from './properties/click-on-text'; export { clickOnText };
-import { clickable }   from './properties/clickable';     export { clickable };
-import { collection }  from './properties/collection';    export { collection };
-import { contains }    from './properties/contains';      export { contains };
-import { count }       from './properties/count';         export { count };
-import { fillable }    from './properties/fillable';      export { fillable }; export const selectable = fillable;
-import { focusable }   from './properties/focusable';     export { focusable };
-import { hasClass }    from './properties/has-class';     export { hasClass };
-import { isHidden }    from './properties/is-hidden';     export { isHidden };
-import { isPresent }   from './properties/is-present';    export { isPresent };
-import { isVisible }   from './properties/is-visible';    export { isVisible };
-import { notHasClass } from './properties/not-has-class'; export { notHasClass };
-import { property }    from './properties/property';      export { property };
-import { text }        from './properties/text';          export { text };
-import { triggerable } from './properties/triggerable';   export { triggerable };
-import { value }       from './properties/value';         export { value };
-import { visitable }   from './properties/visitable';     export { visitable };
+import { attribute } from './properties/attribute';
+export { attribute };
+import { blurrable } from './properties/blurrable';
+export { blurrable };
+import { clickOnText } from './properties/click-on-text';
+export { clickOnText };
+import { clickable } from './properties/clickable';
+export { clickable };
+import { collection } from './properties/collection';
+export { collection };
+import { contains } from './properties/contains';
+export { contains };
+import { count } from './properties/count';
+export { count };
+import { fillable } from './properties/fillable';
+export { fillable };
+export const selectable = fillable;
+import { focusable } from './properties/focusable';
+export { focusable };
+import { hasClass } from './properties/has-class';
+export { hasClass };
+import { isHidden } from './properties/is-hidden';
+export { isHidden };
+import { isPresent } from './properties/is-present';
+export { isPresent };
+import { isVisible } from './properties/is-visible';
+export { isVisible };
+import { notHasClass } from './properties/not-has-class';
+export { notHasClass };
+import { property } from './properties/property';
+export { property };
+import { text } from './properties/text';
+export { text };
+import { triggerable } from './properties/triggerable';
+export { triggerable };
+import { value } from './properties/value';
+export { value };
+import { visitable } from './properties/visitable';
+export { visitable };
 
 export { findElement } from './extend/find-element';
 export { findElementWithAssert } from './extend/find-element-with-assert';
@@ -45,5 +66,5 @@ export default {
   text,
   value,
   visitable,
-  triggerable
+  triggerable,
 };

--- a/addon-test-support/macros/alias.js
+++ b/addon-test-support/macros/alias.js
@@ -1,9 +1,6 @@
 import { throwBetterError } from '../-private/better-errors';
-import {
-  getProperty,
-  objectHasProperty
-} from '../-private/helpers';
-import { chainable } from "../-private/chainable";
+import { getProperty, objectHasProperty } from '../-private/helpers';
+import { chainable } from '../-private/chainable';
 
 const ALIASED_PROP_NOT_FOUND = 'PageObject does not contain aliased property';
 
@@ -83,7 +80,11 @@ export function alias(pathToProp, options = {}) {
 
     get(key) {
       if (!objectHasProperty(this, pathToProp)) {
-        throwBetterError(this, key, `${ALIASED_PROP_NOT_FOUND} \`${pathToProp}\`.`);
+        throwBetterError(
+          this,
+          key,
+          `${ALIASED_PROP_NOT_FOUND} \`${pathToProp}\`.`
+        );
       }
 
       const value = getProperty(this, pathToProp);
@@ -92,7 +93,7 @@ export function alias(pathToProp, options = {}) {
         return value;
       }
 
-      return function(...args) {
+      return function (...args) {
         // We can't just return value(...args) here because if the alias points
         // to a property on a child node, then the return value would be that
         // child node rather than this node.
@@ -100,6 +101,6 @@ export function alias(pathToProp, options = {}) {
 
         return chainable(this);
       };
-    }
+    },
   };
 }

--- a/addon-test-support/macros/getter.js
+++ b/addon-test-support/macros/getter.js
@@ -53,6 +53,6 @@ export function getter(fn) {
       }
 
       return fn.call(this, key);
-    }
+    },
   };
 }

--- a/addon-test-support/properties/attribute.js
+++ b/addon-test-support/properties/attribute.js
@@ -67,10 +67,10 @@ export function attribute(attributeName, selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       return $(findOne(this, selector, options)).attr(attributeName);
-    }
+    },
   };
 }

--- a/addon-test-support/properties/blurrable.js
+++ b/addon-test-support/properties/blurrable.js
@@ -61,18 +61,17 @@ import { findOne } from '../extend';
  * @param {boolean} options.resetScope - Ignore parent scope
  * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
-*/
+ */
 export function blurrable(selector = '', userOptions = {}) {
   return action(
     {
       ...userOptions,
-      selector
+      selector,
     },
-    function() {
+    function () {
       const element = findOne(this.node, this.query.selector, this.query);
 
       return this.adapter.blur(element);
     }
   );
 }
-

--- a/addon-test-support/properties/click-on-text.js
+++ b/addon-test-support/properties/click-on-text.js
@@ -84,24 +84,27 @@ import { findOne, findMany } from '../extend';
  * @return {Descriptor}
  */
 export function clickOnText(scope, userOptions = {}) {
-  return action({
-    ...userOptions,
-     selector: scope
-  }, function(textToClick) {
-    this.query.contains = textToClick;
-    // find the deepest node containing a text to click
-    this.query.last = true;
+  return action(
+    {
+      ...userOptions,
+      selector: scope,
+    },
+    function (textToClick) {
+      this.query.contains = textToClick;
+      // find the deepest node containing a text to click
+      this.query.last = true;
 
-    const childSelector = `${scope || ''} `;
-    let selector;
-    if (findMany(this.node, childSelector, this.query).length) {
-      selector = childSelector;
-    } else {
-      selector = scope;
+      const childSelector = `${scope || ''} `;
+      let selector;
+      if (findMany(this.node, childSelector, this.query).length) {
+        selector = childSelector;
+      } else {
+        selector = scope;
+      }
+
+      const element = findOne(this.node, selector, this.query);
+
+      return this.adapter.click(element);
     }
-
-    const element = findOne(this.node, selector, this.query);
-
-    return this.adapter.click(element);
-  });
+  );
 }

--- a/addon-test-support/properties/clickable.js
+++ b/addon-test-support/properties/clickable.js
@@ -63,7 +63,7 @@ import { findOne } from '../extend';
  * @return {Descriptor}
  */
 export function clickable(selector, userOptions = {}) {
-  return action({ ...userOptions, selector }, function() {
+  return action({ ...userOptions, selector }, function () {
     const element = findOne(this.node, this.query.selector, this.query);
 
     return this.adapter.click(element);

--- a/addon-test-support/properties/collection.js
+++ b/addon-test-support/properties/collection.js
@@ -1,4 +1,3 @@
-/* global Symbol */
 import Ceibo from 'ceibo';
 import {
   buildSelector,

--- a/addon-test-support/properties/collection.js
+++ b/addon-test-support/properties/collection.js
@@ -1,9 +1,13 @@
 /* global Symbol */
 import Ceibo from 'ceibo';
-import { buildSelector, isPageObject, getPageObjectDefinition } from '../-private/helpers';
+import {
+  buildSelector,
+  isPageObject,
+  getPageObjectDefinition,
+} from '../-private/helpers';
 import { create } from '../create';
 import { count } from './count';
-import { throwBetterError } from "../-private/better-errors";
+import { throwBetterError } from '../-private/better-errors';
 
 /**
  * Creates a enumerable that represents a collection of items. The collection is zero-indexed
@@ -147,7 +151,7 @@ export function collection(scope, definition) {
     throw new Error('collection requires `scope` as the first argument');
   }
 
-  if(isPageObject(definition)){
+  if (isPageObject(definition)) {
     //extract the stored definition from the page object
     definition = getPageObjectDefinition(definition);
   }
@@ -159,8 +163,10 @@ export function collection(scope, definition) {
       // Set the value on the descriptor so that it will be picked up and applied by Ceibo.
       // This does mutate the descriptor, but because `setup` is always called before the
       // value is assigned we are guaranteed to get a new, unique Collection instance each time.
-      descriptor.value = proxyIfSupported(new Collection(scope, definition, node, key));
-    }
+      descriptor.value = proxyIfSupported(
+        new Collection(scope, definition, node, key)
+      );
+    },
   };
 
   return descriptor;
@@ -173,12 +179,15 @@ export class Collection {
     this.parent = parent;
     this.key = key;
 
-    this._itemCounter = create({
-      count: count(scope, {
-        resetScope: this.definition.resetScope,
-        testContainer: this.definition.testContainer
-      })
-    }, { parent });
+    this._itemCounter = create(
+      {
+        count: count(scope, {
+          resetScope: this.definition.resetScope,
+          testContainer: this.definition.testContainer,
+        }),
+      },
+      { parent }
+    );
 
     this._items = [];
   }
@@ -250,7 +259,8 @@ export class Collection {
   }
 
   _assertFoundElements(elements, ...args) {
-    const argsToText = args.length === 1 ? 'condition': `${args[0]}: "${args[1]}"`;
+    const argsToText =
+      args.length === 1 ? 'condition' : `${args[0]}: "${args[1]}"`;
     if (elements.length > 1) {
       throwBetterError(
         this.parent,
@@ -260,7 +270,11 @@ export class Collection {
     }
 
     if (elements.length === 0) {
-      throwBetterError(this.parent, this.key, `cannot find element by ${argsToText}`);
+      throwBetterError(
+        this.parent,
+        this.key,
+        `cannot find element by ${argsToText}`
+      );
     }
   }
 
@@ -277,8 +291,8 @@ export class Collection {
   }
 }
 
-if (typeof (Symbol) !== 'undefined' && Symbol.iterator) {
-  Collection.prototype[Symbol.iterator] = function() {
+if (typeof Symbol !== 'undefined' && Symbol.iterator) {
+  Collection.prototype[Symbol.iterator] = function () {
     let i = 0;
     let items = this.toArray();
     let next = () => ({ done: i >= items.length, value: items[i++] });
@@ -291,7 +305,7 @@ function proxyIfSupported(instance) {
   if (window.Proxy) {
     return new window.Proxy(instance, {
       get: function (target, name) {
-        if (typeof (name) === 'number' || typeof (name) === 'string') {
+        if (typeof name === 'number' || typeof name === 'string') {
           let index = parseInt(name, 10);
 
           if (!isNaN(index)) {
@@ -300,7 +314,7 @@ function proxyIfSupported(instance) {
         }
 
         return target[name];
-      }
+      },
     });
   } else {
     return instance;

--- a/addon-test-support/properties/contains.js
+++ b/addon-test-support/properties/contains.js
@@ -65,14 +65,16 @@ export function contains(selector, userOptions = {}) {
     isDescriptor: true,
 
     get(key) {
-      return function(textToSearch) {
+      return function (textToSearch) {
         let options = {
           pageObjectKey: `${key}("${textToSearch}")`,
-          ...userOptions
+          ...userOptions,
         };
 
-        return $(findOne(this, selector, options)).text().indexOf(textToSearch) > -1;
+        return (
+          $(findOne(this, selector, options)).text().indexOf(textToSearch) > -1
+        );
       };
-    }
+    },
   };
 }

--- a/addon-test-support/properties/count.js
+++ b/addon-test-support/properties/count.js
@@ -87,10 +87,10 @@ export function count(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       return findMany(this, selector, options).length;
-    }
+    },
   };
 }

--- a/addon-test-support/properties/fillable.js
+++ b/addon-test-support/properties/fillable.js
@@ -117,7 +117,7 @@ import { findOne } from '../-private/finders';
 export function fillable(selector = '', userOptions = {}) {
   return action(
     { ...userOptions, selector },
-    function(contentOrClue, content) {
+    function (contentOrClue, content) {
       let clue;
       if (content === undefined) {
         content = contentOrClue;
@@ -136,20 +136,22 @@ export function fillable(selector = '', userOptions = {}) {
       const element = findOne(this.node, scopeSelector, this.query);
 
       return this.adapter.fillIn(element, content);
-  });
+    }
+  );
 }
 
 function findSelectorByClue({ node, query }, clue) {
-  let cssClues = ['input', 'textarea', 'select', '[contenteditable]'].map((tag) => [
-    `${tag}[data-test="${clue}"]`,
-    `${tag}[aria-label="${clue}"]`,
-    `${tag}[placeholder="${clue}"]`,
-    `${tag}[name="${clue}"]`,
-    `${tag}#${clue}`
-  ])
-  .reduce((total, other) => total.concat(other), [])
+  let cssClues = ['input', 'textarea', 'select', '[contenteditable]']
+    .map((tag) => [
+      `${tag}[data-test="${clue}"]`,
+      `${tag}[aria-label="${clue}"]`,
+      `${tag}[placeholder="${clue}"]`,
+      `${tag}[name="${clue}"]`,
+      `${tag}#${clue}`,
+    ])
+    .reduce((total, other) => total.concat(other), []);
 
-  return cssClues.find(extraScope => {
+  return cssClues.find((extraScope) => {
     return findMany(node, `${query.selector} ${extraScope}`, query)[0];
   });
 }

--- a/addon-test-support/properties/focusable.js
+++ b/addon-test-support/properties/focusable.js
@@ -61,11 +61,11 @@ import { findOne } from '../extend';
  * @param {boolean} options.resetScope - Ignore parent scope
  * @param {string} options.testContainer - Context where to search elements in the DOM
  * @return {Descriptor}
-*/
+ */
 export function focusable(selector = '', userOptions = {}) {
-  const query = { ...userOptions,  selector };
+  const query = { ...userOptions, selector };
 
-  return action(query, function() {
+  return action(query, function () {
     const element = findOne(this.node, this.query.selector, this.query);
 
     return this.adapter.focus(element);

--- a/addon-test-support/properties/has-class.js
+++ b/addon-test-support/properties/has-class.js
@@ -71,12 +71,12 @@ export function hasClass(cssClass, selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let element = findOne(this, selector, options);
 
       return element.classList.contains(cssClass);
-    }
+    },
   };
 }

--- a/addon-test-support/properties/is-hidden.js
+++ b/addon-test-support/properties/is-hidden.js
@@ -77,7 +77,7 @@ export function isHidden(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let elements = findMany(this, selector, options);
@@ -85,6 +85,6 @@ export function isHidden(selector, userOptions = {}) {
       guardMultiple(elements, selector);
 
       return elements.length === 0 || $(elements[0]).is(':hidden');
-    }
+    },
   };
 }

--- a/addon-test-support/properties/is-present.js
+++ b/addon-test-support/properties/is-present.js
@@ -72,13 +72,13 @@ export function isPresent(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector);
 
       return elements.length === 1;
-    }
+    },
   };
 }

--- a/addon-test-support/properties/is-visible.js
+++ b/addon-test-support/properties/is-visible.js
@@ -83,13 +83,13 @@ export function isVisible(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let elements = findMany(this, selector, options);
       guardMultiple(elements, selector, options.multiple);
 
       return elements.length === 1 && $(elements[0]).is(':visible');
-    }
+    },
   };
 }

--- a/addon-test-support/properties/not-has-class.js
+++ b/addon-test-support/properties/not-has-class.js
@@ -73,12 +73,12 @@ export function notHasClass(cssClass, selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let element = findOne(this, selector, options);
 
       return !element.classList.contains(cssClass);
-    }
+    },
   };
 }

--- a/addon-test-support/properties/property.js
+++ b/addon-test-support/properties/property.js
@@ -51,11 +51,10 @@ export function property(propertyName, selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
-
       return $(findOne(this, selector, options)).prop(propertyName);
-    }
+    },
   };
 }

--- a/addon-test-support/properties/text.js
+++ b/addon-test-support/properties/text.js
@@ -91,12 +91,12 @@ export function text(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       let f = options.normalize === false ? identity : normalizeText;
       return f($(findOne(this, selector, options)).text());
-    }
+    },
   };
 }
 

--- a/addon-test-support/properties/triggerable.js
+++ b/addon-test-support/properties/triggerable.js
@@ -77,17 +77,22 @@ import { findOne } from '../extend';
  * @param {string} options.testContainer - Context where to search elements in the DOM
  * @param {string} options.eventProperties - Event properties that will be passed to trigger function
  * @return {Descriptor}
-*/
+ */
 export function triggerable(event, selector, userOptions = {}) {
-  return action(({
-    ...userOptions,
-    selector
-  }), function (eventProperties = {}) {
-    const mergedEventProperties = { ...userOptions.eventProperties, ...eventProperties };
+  return action(
+    {
+      ...userOptions,
+      selector,
+    },
+    function (eventProperties = {}) {
+      const mergedEventProperties = {
+        ...userOptions.eventProperties,
+        ...eventProperties,
+      };
 
-    const element = findOne(this.node, this.query.selector, this.query);
+      const element = findOne(this.node, this.query.selector, this.query);
 
-    return this.adapter.triggerEvent(element, event, mergedEventProperties);
-  });
+      return this.adapter.triggerEvent(element, event, mergedEventProperties);
+    }
+  );
 }
-

--- a/addon-test-support/properties/value.js
+++ b/addon-test-support/properties/value.js
@@ -79,12 +79,14 @@ export function value(selector, userOptions = {}) {
     get(key) {
       let options = {
         pageObjectKey: key,
-        ...userOptions
+        ...userOptions,
       };
 
       const element = findOne(this, selector, options);
 
-      return element.hasAttribute('contenteditable') ? $(element).html() : $(element).val();
-    }
+      return element.hasAttribute('contenteditable')
+        ? $(element).html()
+        : $(element).val();
+    },
   };
 }

--- a/addon-test-support/properties/visitable.js
+++ b/addon-test-support/properties/visitable.js
@@ -1,26 +1,29 @@
 import { $ } from '../-private/helpers';
-import action from '../-private/action'
+import action from '../-private/action';
 
 function fillInDynamicSegments(path, params) {
-  return path.split('/').map(function(segment) {
-    let match = segment.match(/^:(.+)$/);
+  return path
+    .split('/')
+    .map(function (segment) {
+      let match = segment.match(/^:(.+)$/);
 
-    if (match) {
-      let [, key] = match;
-      let value = params[key];
+      if (match) {
+        let [, key] = match;
+        let value = params[key];
 
-      if (typeof (value) === 'undefined') {
-        throw new Error(`Missing parameter for '${key}'`);
+        if (typeof value === 'undefined') {
+          throw new Error(`Missing parameter for '${key}'`);
+        }
+
+        // Remove dynamic segment key from params
+        delete params[key];
+
+        return encodeURIComponent(value);
       }
 
-      // Remove dynamic segment key from params
-      delete params[key];
-
-      return encodeURIComponent(value);
-    }
-
-    return segment;
-  }).join('/');
+      return segment;
+    })
+    .join('/');
 }
 
 function appendQueryParams(path, queryParams) {
@@ -88,7 +91,7 @@ function appendQueryParams(path, queryParams) {
  * @throws Will throw an error if dynamic segments are not filled
  */
 export function visitable(path) {
-  return action(function(dynamicSegmentsAndQueryParams = {}) {
+  return action(function (dynamicSegmentsAndQueryParams = {}) {
     let params = { ...dynamicSegmentsAndQueryParams };
     let fullPath = fillInDynamicSegments(path, params);
 

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,14 +1,10 @@
-const { buildEmberPlugins } = require("ember-cli-babel");
+const { buildEmberPlugins } = require('ember-cli-babel');
 
 module.exports = function (api) {
   api.cache(true);
 
   return {
-    presets: [
-      [
-        require.resolve('@babel/preset-env'),
-      ],
-    ],
+    presets: [[require.resolve('@babel/preset-env')]],
     plugins: [
       ...buildEmberPlugins(__dirname, {
         shouldIgnoreJQuery: true,

--- a/blueprints/page-object-component/index.js
+++ b/blueprints/page-object-component/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: 'Generates a component object to be used on a page object.'
+  description: 'Generates a component object to be used on a page object.',
 };

--- a/blueprints/page-object-helper/index.js
+++ b/blueprints/page-object-helper/index.js
@@ -1,4 +1,4 @@
 /*jshint node:true*/
 module.exports = {
-  description: 'Generates a helper to be used on a page object.'
+  description: 'Generates a helper to be used on a page object.',
 };

--- a/blueprints/page-object/index.js
+++ b/blueprints/page-object/index.js
@@ -1,3 +1,3 @@
 module.exports = {
-  description: 'Generates a page object for acceptance tests.'
+  description: 'Generates a page object for acceptance tests.',
 };

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -1,7 +1,5 @@
 'use strict';
 
 module.exports = {
-  excludes: [
-    'tests/dummy/**/*'
-  ]
+  excludes: ['tests/dummy/**/*'],
 };

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -2,11 +2,11 @@
 
 const getChannelURL = require('ember-source-channel-url');
 
-module.exports = function() {
+module.exports = function () {
   return Promise.all([
     getChannelURL('release'),
     getChannelURL('beta'),
-    getChannelURL('canary')
+    getChannelURL('canary'),
   ]).then((urls) => {
     return {
       scenarios: [
@@ -14,35 +14,35 @@ module.exports = function() {
           name: 'ember-lts-2.4',
           bower: {
             dependencies: {
-              'ember': 'components/ember#lts-2-4'
+              ember: 'components/ember#lts-2-4',
             },
             resolutions: {
-              'ember': 'lts-2-4'
-            }
+              ember: 'lts-2-4',
+            },
           },
           npm: {
             devDependencies: {
               'ember-source': null,
               'ember-cli-qunit': '^4.0.0',
-              'ember-qunit': null
-            }
-          }
+              'ember-qunit': null,
+            },
+          },
         },
         {
           name: 'ember-lts-2.8',
           bower: {
             dependencies: {
-              'ember': 'components/ember#lts-2-8'
+              ember: 'components/ember#lts-2-8',
             },
             resolutions: {
-              'ember': 'lts-2-8'
-            }
+              ember: 'lts-2-8',
+            },
           },
           npm: {
             devDependencies: {
-              'ember-source': null
-            }
-          }
+              'ember-source': null,
+            },
+          },
         },
         {
           name: 'ember-lts-2.12',
@@ -50,129 +50,133 @@ module.exports = function() {
             devDependencies: {
               'ember-source': '~2.12.0',
               'ember-cli-qunit': '^4.0.0',
-              'ember-qunit': null
-            }
-          }
+              'ember-qunit': null,
+            },
+          },
         },
         {
           name: 'ember-lts-2.16',
           env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true,
+            }),
           },
           npm: {
             devDependencies: {
               '@ember/jquery': '^0.5.1',
               'ember-source': '~2.16.0',
               'ember-cli-qunit': '^4.0.0',
-              'ember-qunit': null
-            }
-          }
+              'ember-qunit': null,
+            },
+          },
         },
         {
           name: 'ember-lts-2.18',
           env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true,
+            }),
           },
           npm: {
             devDependencies: {
               '@ember/jquery': '^0.5.1',
-              'ember-source': '~2.18.0'
-            }
-          }
+              'ember-source': '~2.18.0',
+            },
+          },
         },
         {
           name: 'ember-lts-3.28',
           npm: {
             devDependencies: {
-              'ember-source': '~3.28.0'
-            }
+              'ember-source': '~3.28.0',
+            },
           },
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
-            })
-          }
+              'jquery-integration': false,
+            }),
+          },
         },
 
         {
           name: 'ember-release',
           npm: {
             devDependencies: {
-              'ember-source': urls[0]
-            }
+              'ember-source': urls[0],
+            },
           },
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
-            })
-          }
+              'jquery-integration': false,
+            }),
+          },
         },
         {
           name: 'ember-beta',
           npm: {
             devDependencies: {
-              'ember-source': urls[1]
-            }
+              'ember-source': urls[1],
+            },
           },
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
-            })
-          }
+              'jquery-integration': false,
+            }),
+          },
         },
         {
           name: 'ember-canary',
           npm: {
             devDependencies: {
-              'ember-source': urls[2]
-            }
+              'ember-source': urls[2],
+            },
           },
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
-            })
-          }
+              'jquery-integration': false,
+            }),
+          },
         },
         {
           name: 'ember-default',
           npm: {
-            devDependencies: {}
-          }
+            devDependencies: {},
+          },
         },
         {
           name: 'with-ember-test-helpers',
           bower: {
             dependencies: {
-              'ember': 'components/ember#release'
+              ember: 'components/ember#release',
             },
             resolutions: {
-              'ember': 'release'
-            }
+              ember: 'release',
+            },
           },
           npm: {
             devDependencies: {
               'ember-cli-qunit': '4.0.0',
               'ember-source': null,
-              'ember-qunit': null
-            }
-          }
+              'ember-qunit': null,
+            },
+          },
         },
         {
           name: 'with-@ember/test-helpers',
           bower: {
             dependencies: {
-              'ember': 'components/ember#release'
+              ember: 'components/ember#release',
             },
             resolutions: {
-              'ember': 'release'
-            }
+              ember: 'release',
+            },
           },
           npm: {
             devDependencies: {
               'ember-cli-qunit': '4.3.0',
-              'ember-source': null
-            }
-          }
+              'ember-source': null,
+            },
+          },
         },
         {
           name: 'with-ember-qunit@5',
@@ -180,33 +184,33 @@ module.exports = function() {
             devDependencies: {
               'ember-source': '^3.28.0',
               'ember-qunit': '^5.0.0',
-              'qunit': '~2.14.0',
+              qunit: '~2.14.0',
               '@ember/test-helpers': '^2.0.0',
               'ember-qunit-source-map': null,
-            }
+            },
           },
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': false
-            })
-          }
+              'jquery-integration': false,
+            }),
+          },
         },
         {
           name: 'node-tests',
           command: 'npm run nodetest',
           bower: {
-            dependencies: {}
-          }
+            dependencies: {},
+          },
         },
         {
           name: 'with-jquery',
           env: {
             EMBER_OPTIONAL_FEATURES: JSON.stringify({
-              'jquery-integration': true
-            })
-          }
-        }
-      ]
+              'jquery-integration': true,
+            }),
+          },
+        },
+      ],
     };
   });
 };

--- a/index.js
+++ b/index.js
@@ -5,17 +5,17 @@ module.exports = {
 
   options: {
     'ember-cli-babel': {
-      useBabelConfig: true
+      useBabelConfig: true,
     },
     nodeAssets: {
       ceibo: {
-        vendor: ['index.js']
+        vendor: ['index.js'],
       },
       jquery: {
         vendor: ['dist/jquery.js'],
-        destDir: 'ecpo-jquery'
-      }
-    }
+        destDir: 'ecpo-jquery',
+      },
+    },
   },
 
   included() {
@@ -46,38 +46,34 @@ module.exports = {
     //
     // which is a default behavior in ember-cli
     const reexportsTree = mergeTrees(
-      [
-        'index',
-        'extend',
-        'macros',
-        'adapter',
-        'adapters',
-      ].map(publicModuleName =>
-        writeFile(
-          `/${this.moduleName()}/${publicModuleName}.js`,
-          `export * from '${this.moduleName()}/test-support/${publicModuleName}';`
-        )
-      ).concat(
-        [
-          'adapters/acceptance-native-events',
-          'adapters/acceptance',
-          'adapters/integration-native-events',
-          'adapters/integration',
-          'adapters/rfc268',
-        ].map(publicModuleName =>
+      ['index', 'extend', 'macros', 'adapter', 'adapters']
+        .map((publicModuleName) =>
           writeFile(
             `/${this.moduleName()}/${publicModuleName}.js`,
-            `export { default } from '${this.moduleName()}/test-support/${publicModuleName}';`
+            `export * from '${this.moduleName()}/test-support/${publicModuleName}';`
           )
         )
-      )
+        .concat(
+          [
+            'adapters/acceptance-native-events',
+            'adapters/acceptance',
+            'adapters/integration-native-events',
+            'adapters/integration',
+            'adapters/rfc268',
+          ].map((publicModuleName) =>
+            writeFile(
+              `/${this.moduleName()}/${publicModuleName}.js`,
+              `export { default } from '${this.moduleName()}/test-support/${publicModuleName}';`
+            )
+          )
+        )
     );
 
     return mergeTrees([
       testSupportTree,
-      this.preprocessJs(
-        reexportsTree, '/', this.name, { registry: this.registry, }
-      )
+      this.preprocessJs(reexportsTree, '/', this.name, {
+        registry: this.registry,
+      }),
     ]);
   },
 
@@ -90,5 +86,5 @@ module.exports = {
     } while (current.parent.parent && (current = current.parent));
 
     return app;
-  }
+  },
 };

--- a/test-support/page-object.js
+++ b/test-support/page-object.js
@@ -22,7 +22,7 @@ import {
   text,
   triggerable,
   value,
-  visitable
+  visitable,
 } from 'ember-cli-page-object';
 
 export {
@@ -47,7 +47,7 @@ export {
   text,
   triggerable,
   value,
-  visitable
+  visitable,
 };
 
 export default {
@@ -73,14 +73,20 @@ export default {
   text,
   triggerable,
   value,
-  visitable
+  visitable,
 };
 
-export { buildSelector, findElementWithAssert, findElement, getContext, fullScope } from 'ember-cli-page-object';
+export {
+  buildSelector,
+  findElementWithAssert,
+  findElement,
+  getContext,
+  fullScope,
+} from 'ember-cli-page-object';
 
 deprecate(
   'import-from-test-support',
   `Importing from "test-support" is now deprecated. Please import directly from the "ember-cli-page-object" module instead.`,
   '1.16.0',
-  '2.0.0',
-)
+  '2.0.0'
+);

--- a/testem.js
+++ b/testem.js
@@ -6,7 +6,7 @@ module.exports = {
   launch_in_ci: ['Chrome'],
   launch_in_dev: ['Chrome'],
   browser_start_timeout: 120,
- browser_args: {
+  browser_args: {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container

--- a/tests/acceptance/collection-test.js
+++ b/tests/acceptance/collection-test.js
@@ -1,11 +1,7 @@
 import { module, test } from 'qunit';
 import { setupApplicationTest } from '../helpers';
 
-import {
-  create,
-  collection,
-  visitable
-} from 'ember-cli-page-object';
+import { create, collection, visitable } from 'ember-cli-page-object';
 
 const page = create({
   visit: visitable('async-calculator'),

--- a/tests/acceptance/composition-test.js
+++ b/tests/acceptance/composition-test.js
@@ -9,50 +9,45 @@ import {
   clickable,
   value,
   fillable,
-  clickOnText
+  clickOnText,
 } from 'ember-cli-page-object';
 
 let keyboard = create({
   scope: '.keyboard',
-  numbers: collection(".numbers button", {
+  numbers: collection('.numbers button', {
     text: text(),
-    click: clickable()
+    click: clickable(),
   }),
-  operators: collection(".operators button", {
-    text: text()
+  operators: collection('.operators button', {
+    text: text(),
   }),
   clickOn: clickOnText('.numbers'),
   sum: clickable('button', { scope: '.operators', at: 0 }),
-  equal: clickable('button', { scope: '.operators', at: 2 })
+  equal: clickable('button', { scope: '.operators', at: 2 }),
 });
 
 let screenPage = create({
   value: value('.screen input'),
-  fillValue: fillable('.screen input')
+  fillValue: fillable('.screen input'),
 });
 let page = create({
   visit: visitable('/calculator'),
   keys: keyboard,
-  screen: screenPage
+  screen: screenPage,
 });
 
-module('Acceptance | composition', function(hooks) {
+module('Acceptance | composition', function (hooks) {
   setupApplicationTest(hooks);
 
-  test('allows compose', async function(assert) {
-    await page
-      .visit()
-      .keys
-      .clickOn('1')
-      .clickOn('2')
-      .sum();
+  test('allows compose', async function (assert) {
+    await page.visit().keys.clickOn('1').clickOn('2').sum();
     //click 3
-    await page.keys.numbers.objectAt(2).click()
+    await page.keys.numbers.objectAt(2).click();
     //click =
     await page.keys.operators.objectAt(3).click();
     assert.equal(page.screen.value, '15');
 
-    await page.screen.fillValue('45')
+    await page.screen.fillValue('45');
     //click 6
     await page.keys.numbers.objectAt(5).click();
 

--- a/tests/acceptance/rfc268-actions-test.js
+++ b/tests/acceptance/rfc268-actions-test.js
@@ -7,7 +7,7 @@ import {
   fillable,
   isVisible,
   value,
-  visitable
+  visitable,
 } from 'ember-cli-page-object';
 
 import { alias } from 'ember-cli-page-object/macros';

--- a/tests/acceptance/rfc268-test.js
+++ b/tests/acceptance/rfc268-test.js
@@ -1,9 +1,5 @@
 import { module, test } from 'qunit';
-import {
-  create,
-  value,
-  visitable,
-} from 'ember-cli-page-object';
+import { create, value, visitable } from 'ember-cli-page-object';
 import { setupApplicationTest } from '../helpers';
 
 module('Acceptance | rfc268', function (hooks) {

--- a/tests/dummy/app/templates/async-calculator.hbs
+++ b/tests/dummy/app/templates/async-calculator.hbs
@@ -1,7 +1,7 @@
 <h1>Async Calculator</h1>
 
 {{#if this.isPrimeTime}}
-  {{component "calculating-device"}}
+  <CalculatingDevice />
 {{else}}
   Loading...
 {{/if}}

--- a/tests/dummy/app/templates/calculator.hbs
+++ b/tests/dummy/app/templates/calculator.hbs
@@ -12,22 +12,22 @@
   </div>
   <div class="keyboard">
     <div class="numbers">
-      <button {{action "keyPress" "1"}}>1</button>
-      <button {{action "keyPress" "2"}}>2</button>
-      <button {{action "keyPress" "3"}}>3</button>
-      <button {{action "keyPress" "4"}}>4</button>
-      <button {{action "keyPress" "5"}}>5</button>
-      <button {{action "keyPress" "6"}}>6</button>
-      <button {{action "keyPress" "7"}}>7</button>
-      <button {{action "keyPress" "8"}}>8</button>
-      <button {{action "keyPress" "9"}}>9</button>
-      <button {{action "keyPress" "0"}}>0</button>
+      <button type="button" {{action "keyPress" "1"}}>1</button>
+      <button type="button" {{action "keyPress" "2"}}>2</button>
+      <button type="button" {{action "keyPress" "3"}}>3</button>
+      <button type="button" {{action "keyPress" "4"}}>4</button>
+      <button type="button" {{action "keyPress" "5"}}>5</button>
+      <button type="button" {{action "keyPress" "6"}}>6</button>
+      <button type="button" {{action "keyPress" "7"}}>7</button>
+      <button type="button" {{action "keyPress" "8"}}>8</button>
+      <button type="button" {{action "keyPress" "9"}}>9</button>
+      <button type="button" {{action "keyPress" "0"}}>0</button>
     </div>
     <div class="operators">
-      <button {{action "keyPress" "+"}}>+</button>
-      <button {{action "keyPress" "-"}}>-</button>
-      <button {{action "keyPress" "="}}>=</button>
-      <button {{action "keyPress" "=" true}}>async=</button>
+      <button type="button" {{action "keyPress" "+"}}>+</button>
+      <button type="button" {{action "keyPress" "-"}}>-</button>
+      <button type="button" {{action "keyPress" "="}}>=</button>
+      <button type="button" {{action "keyPress" "=" true}}>async=</button>
     </div>
   </div>
 </div>

--- a/tests/dummy/app/templates/components/calculating-device.hbs
+++ b/tests/dummy/app/templates/components/calculating-device.hbs
@@ -7,21 +7,21 @@
   </div>
   <div class="keyboard">
     <div class="numbers">
-      <button {{action "keyPress" "1"}}>1</button>
-      <button {{action "keyPress" "2"}}>2</button>
-      <button {{action "keyPress" "3"}}>3</button>
-      <button {{action "keyPress" "4"}}>4</button>
-      <button {{action "keyPress" "5"}}>5</button>
-      <button {{action "keyPress" "6"}}>6</button>
-      <button {{action "keyPress" "7"}}>7</button>
-      <button {{action "keyPress" "8"}}>8</button>
-      <button {{action "keyPress" "9"}}>9</button>
-      <button {{action "keyPress" "0"}}>0</button>
+      <button type="button" {{action "keyPress" "1"}}>1</button>
+      <button type="button" {{action "keyPress" "2"}}>2</button>
+      <button type="button" {{action "keyPress" "3"}}>3</button>
+      <button type="button" {{action "keyPress" "4"}}>4</button>
+      <button type="button" {{action "keyPress" "5"}}>5</button>
+      <button type="button" {{action "keyPress" "6"}}>6</button>
+      <button type="button" {{action "keyPress" "7"}}>7</button>
+      <button type="button" {{action "keyPress" "8"}}>8</button>
+      <button type="button" {{action "keyPress" "9"}}>9</button>
+      <button type="button" {{action "keyPress" "0"}}>0</button>
     </div>
     <div class="operators">
-      <button {{action "keyPress" "+"}}>+</button>
-      <button {{action "keyPress" "-"}}>-</button>
-      <button {{action "keyPress" "="}}>=</button>
+      <button type="button" {{action "keyPress" "+"}}>+</button>
+      <button type="button" {{action "keyPress" "-"}}>-</button>
+      <button type="button" {{action "keyPress" "="}}>=</button>
     </div>
   </div>
 </div>

--- a/tests/dummy/app/templates/components/login-form.hbs
+++ b/tests/dummy/app/templates/components/login-form.hbs
@@ -11,7 +11,7 @@
     {{input id="password" type="password" value=this.password}}
   </label>
 
-  <button {{action "logIn"}}>Log in</button>
+  <button type="button" {{action "logIn"}}>Log in</button>
 </form>
 
 <p class="message">{{this.message}}</p>

--- a/tests/dummy/app/templates/html-render.hbs
+++ b/tests/dummy/app/templates/html-render.hbs
@@ -1,1 +1,1 @@
-{{component "html-render" html=this.html}}
+<HtmlRender @html={{this.html}} />

--- a/tests/dummy/app/templates/inputs.hbs
+++ b/tests/dummy/app/templates/inputs.hbs
@@ -1,1 +1,1 @@
-{{component "input-elements"}}
+<InputElements />

--- a/tests/legacy-test-helper.js
+++ b/tests/legacy-test-helper.js
@@ -1,7 +1,5 @@
 import resolver from './helpers/legacy-resolver';
-import {
-  setResolver
-} from 'ember-qunit';
+import { setResolver } from 'ember-qunit';
 import { start } from 'ember-cli-qunit';
 
 setResolver(resolver);

--- a/tests/unit/-private/action-test.js
+++ b/tests/unit/-private/action-test.js
@@ -1,7 +1,7 @@
 import { module, test } from 'qunit';
-import { create } from 'ember-cli-page-object'
-import action from 'ember-cli-page-object/test-support/-private/action'
-import { isPageObject } from 'ember-cli-page-object/test-support/-private/helpers'
+import { create } from 'ember-cli-page-object';
+import action from 'ember-cli-page-object/test-support/-private/action';
+import { isPageObject } from 'ember-cli-page-object/test-support/-private/helpers';
 import { setAdapter } from 'ember-cli-page-object/test-support/adapters';
 import Adapter from 'ember-cli-page-object/test-support/adapter';
 
@@ -15,62 +15,65 @@ const DEFAULT_NEXT_TICK_TIMEOUT = 20;
 
 const next = (timeout = DEFAULT_NEXT_TICK_TIMEOUT) => {
   return new Promise((r) => setTimeout(r, timeout));
-}
+};
 
 class Deferred {
   constructor() {
-    this.promise = new Promise(function(resolve, reject) {
-			this.resolve = resolve;
-			this.reject = reject;
-    }.bind(this));
+    this.promise = new Promise(
+      function (resolve, reject) {
+        this.resolve = resolve;
+        this.reject = reject;
+      }.bind(this)
+    );
 
-		Object.freeze(this);
+    Object.freeze(this);
   }
 }
 
-module('Unit | action', function(hooks) {
-  hooks.beforeEach(function() {
-    setAdapter(new DummyAdapter);
+module('Unit | action', function (hooks) {
+  hooks.beforeEach(function () {
+    setAdapter(new DummyAdapter());
   });
 
-  let invoked,
-    finished,
-    executionContext;
+  let invoked, finished, executionContext;
 
   const testable = (query) => {
-    return action(query, function(id, deferred) {
+    return action(query, function (id, deferred) {
       invoked.push(id);
       executionContext = this;
 
       return deferred.promise.then(() => {
         finished.push(id);
       });
-    })
-  }
+    });
+  };
 
-  hooks.beforeEach(function() {
+  hooks.beforeEach(function () {
     invoked = [];
     finished = [];
     executionContext = null;
-  })
+  });
 
-  test('it works', async function(assert) {
+  test('it works', async function (assert) {
     const p = create({
       scope: 'it works',
 
-      run: testable({ selector: '.Selector' })
+      run: testable({ selector: '.Selector' }),
     });
 
     const d1 = new Deferred();
     p.run(1, d1);
 
-    assert.equal(typeof executionContext === 'object' && executionContext !== null, true);
+    assert.equal(
+      typeof executionContext === 'object' && executionContext !== null,
+      true
+    );
     assert.deepEqual(executionContext.query, {
       key: `run("1", "[object Object]")`,
-      selector: '.Selector'
+      selector: '.Selector',
     });
     assert.equal(executionContext.node, p, '');
-    assert.equal(executionContext.adapter instanceof DummyAdapter, true)
+    assert.equal(executionContext.adapter instanceof DummyAdapter, true);
 
     assert.deepEqual(invoked, [1]);
     assert.deepEqual(finished, []);
@@ -81,53 +84,59 @@ module('Unit | action', function(hooks) {
     assert.deepEqual(finished, [1]);
   });
 
-  test('this is frozen', async function(assert) {
+  test('this is frozen', async function (assert) {
     const p = create({
       scope: 'it works',
 
-      run: action(function() {
+      run: action(function () {
         executionContext = this;
-      })
+      }),
     });
 
     await p.run();
 
     assert.throws(() => {
       executionContext.test = 1;
-    })
+    });
   });
 
-  test('it handles sync errors', async function(assert) {
+  test('it handles sync errors', async function (assert) {
     const p = create({
       scope: '.Scope',
 
-      run: action({ selector: '.Selector' }, function() {
+      run: action({ selector: '.Selector' }, function () {
         throw new Error('it was so fast!');
-      })
-    })
+      }),
+    });
 
-    assert.throws(() => p.run(1), new Error(`it was so fast!
+    assert.throws(
+      () => p.run(1),
+      new Error(`it was so fast!
 
 PageObject: 'page.run("1")'
-  Selector: '.Scope .Selector'`));
+  Selector: '.Scope .Selector'`)
+    );
   });
 
-  test('it handles sync errors w/o query', async function(assert) {
+  test('it handles sync errors w/o query', async function (assert) {
     const p = create({
       scope: '.Scope',
 
-      run: action(function() {
+      run: action(function () {
         throw new Error('it was so fast!');
-      })
-    })
+      }),
+    });
 
-    assert.throws(() => p.run(1), new Error(`it was so fast!
+    assert.throws(
+      () => p.run(1),
+      new Error(`it was so fast!
 
 PageObject: 'page.run("1")'
-  Selector: '.Scope'`));
+  Selector: '.Scope'`)
+    );
   });
 
-  test('it handles async errors', async function(assert) {
+  test('it handles async errors', async function (assert) {
     // when test against some old `ember-cli-qunit`-only scenarios, QUnit@1 is installed.
     // There is no `assert.rejects(` support, so we just ignore the test in such cases.
     // It's still tested on newer scenarios with QUnit@2, even against old "ember-test-helpers" scenarios.
@@ -137,24 +146,27 @@ PageObject: 'page.run("1")'
       const p = create({
         scope: '.Scope',
 
-        run: action({ selector: '.Selector' }, function() {
+        run: action({ selector: '.Selector' }, function () {
           return next().then(() => {
             throw new Error('bed time');
-          })
-        })
-      })
+          });
+        }),
+      });
 
-      assert.rejects(p.run(1), new Error(`bed time
+      assert.rejects(
+        p.run(1),
+        new Error(`bed time
 
 PageObject: 'page.run("1")'
-  Selector: '.Scope .Selector'`));
+  Selector: '.Scope .Selector'`)
+      );
     } else {
       assert.expect(0);
     }
   });
 
-  module('chainability', function() {
-    test('it works', async function(assert) {
+  module('chainability', function () {
+    test('it works', async function (assert) {
       const p = create({
         scope: '.root',
 
@@ -164,7 +176,7 @@ PageObject: 'page.run("1")'
           scope: '.child',
 
           run: testable({ selector: '.Selector2' }),
-        }
+        },
       });
 
       const d1 = new Deferred();
@@ -206,11 +218,11 @@ PageObject: 'page.run("1")'
       assert.deepEqual(finished, [1, 2, 3]);
     });
 
-    test('concurrent from same root', async function(assert) {
+    test('concurrent from same root', async function (assert) {
       const p = create({
         scope: '.root',
 
-        run: testable({ selector: '.Selector1' })
+        run: testable({ selector: '.Selector1' }),
       });
 
       const d1 = new Deferred();
@@ -253,11 +265,11 @@ PageObject: 'page.run("1")'
       assert.deepEqual(finished, ['1', '1.2', '1.1']);
     });
 
-    test('concurrent from same chain root', async function(assert) {
+    test('concurrent from same chain root', async function (assert) {
       const p = create({
         scope: '.root',
 
-        run: testable({ selector: '.Selector1' })
+        run: testable({ selector: '.Selector1' }),
       });
 
       const d1 = new Deferred();
@@ -309,7 +321,7 @@ PageObject: 'page.run("1")'
       assert.deepEqual(finished, ['1', '1.1', '1.2']);
     });
 
-    test('it handles errors', async function(assert) {
+    test('it handles errors', async function (assert) {
       // when test against some old `ember-cli-qunit`-only scenarios, QUnit@1 is installed.
       // There is no `assert.rejects(` support, so we just ignore the test in such cases.
       // It's still tested on newer scenarios with QUnit@2, even against old "ember-test-helpers" scenarios.
@@ -324,18 +336,21 @@ PageObject: 'page.run("1")'
           child: {
             scope: '.child',
 
-            run: action({ selector: '.Selector2' }, function() {
+            run: action({ selector: '.Selector2' }, function () {
               return next().then(() => {
                 throw new Error('bed time');
-              })
-            })
-          }
-        })
+              });
+            }),
+          },
+        });
 
-        assert.rejects(p.emptyRun().child.run(1), new Error(`bed time
+        assert.rejects(
+          p.emptyRun().child.run(1),
+          new Error(`bed time
 
 PageObject: 'page.child.run("1")'
-  Selector: '.root .child .Selector2'`));
+  Selector: '.root .child .Selector2'`)
+        );
       } else {
         assert.expect(0);
       }

--- a/tests/unit/-private/better-errors-test.js
+++ b/tests/unit/-private/better-errors-test.js
@@ -1,17 +1,15 @@
 import { test, module } from 'qunit';
 import { create } from 'ember-cli-page-object';
-import {
-  throwBetterError
-} from 'ember-cli-page-object/test-support/-private/better-errors';
+import { throwBetterError } from 'ember-cli-page-object/test-support/-private/better-errors';
 
 const page = create({
   foo: {
     scope: '.foo',
     bar: {
       scope: '.bar',
-      focus() {}
-    }
-  }
+      focus() {},
+    },
+  },
 });
 
 module('Unit | throwBetterError', function () {

--- a/tests/unit/-private/composition-test.js
+++ b/tests/unit/-private/composition-test.js
@@ -12,13 +12,10 @@ import {
   collection,
   isVisible,
   text,
-  value
+  value,
 } from 'ember-cli-page-object';
 
-import {
-  alias,
-  getter,
-} from 'ember-cli-page-object/macros';
+import { alias, getter } from 'ember-cli-page-object/macros';
 
 module('Unit | composition', function () {
   test('each page object node stores its definition', function (assert) {
@@ -303,5 +300,3 @@ module('Unit | composition', function () {
     });
   });
 });
-
-

--- a/tests/unit/-private/helpers-test.js
+++ b/tests/unit/-private/helpers-test.js
@@ -3,7 +3,7 @@ import { create, collection } from 'ember-cli-page-object';
 import {
   fullScope,
   getProperty,
-  objectHasProperty
+  objectHasProperty,
 } from 'ember-cli-page-object/test-support/-private/helpers';
 
 module('Unit | helpers | fullScope', function () {

--- a/tests/unit/-private/helpers-test.js
+++ b/tests/unit/-private/helpers-test.js
@@ -1,10 +1,6 @@
 import { test, module } from 'qunit';
 import { create, collection } from 'ember-cli-page-object';
-import {
-  fullScope,
-  getProperty,
-  objectHasProperty,
-} from 'ember-cli-page-object/test-support/-private/helpers';
+import { fullScope } from 'ember-cli-page-object/test-support/-private/helpers';
 
 module('Unit | helpers | fullScope', function () {
   let page = create({

--- a/tests/unit/-private/properties/attribute-test.js
+++ b/tests/unit/-private/properties/attribute-test.js
@@ -9,7 +9,7 @@ module('attribute', function (hooks) {
 
   test('returns attribute value', async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input')
+      foo: attribute('placeholder', ':input'),
     });
 
     await render(hbs`<input placeholder="a value">`);
@@ -17,9 +17,9 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test("returns null when attribute doesn't exist", async function(assert) {
+  test("returns null when attribute doesn't exist", async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input')
+      foo: attribute('placeholder', ':input'),
     });
 
     await render(hbs`<input>`);
@@ -27,15 +27,15 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, null);
   });
 
-  test("raises an error when the element doesn't exist", async function(assert) {
+  test("raises an error when the element doesn't exist", async function (assert) {
     let page = create({
       foo: {
         bar: {
           baz: {
-            qux: attribute('placeholder', ':input')
-          }
-        }
-      }
+            qux: attribute('placeholder', ':input'),
+          },
+        },
+      },
     });
 
     await render(hbs``);
@@ -43,9 +43,9 @@ module('attribute', function (hooks) {
     assert.throws(() => page.foo.bar.baz.qux, /page\.foo\.bar\.baz\.qux/);
   });
 
-  test('looks for elements inside the scope', async function(assert) {
+  test('looks for elements inside the scope', async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input', { scope: '.scope' })
+      foo: attribute('placeholder', ':input', { scope: '.scope' }),
     });
 
     await render(hbs`
@@ -57,11 +57,11 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test("looks for elements inside page's scope", async function(assert) {
+  test("looks for elements inside page's scope", async function (assert) {
     let page = create({
       scope: '.scope',
 
-      foo: attribute('placeholder', ':input')
+      foo: attribute('placeholder', ':input'),
     });
 
     await render(hbs`
@@ -73,11 +73,11 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test('resets scope', async function(assert) {
+  test('resets scope', async function (assert) {
     let page = create({
       scope: '.scope',
 
-      foo: attribute('placeholder', ':input', { resetScope: true })
+      foo: attribute('placeholder', ':input', { resetScope: true }),
     });
 
     await render(hbs`
@@ -88,9 +88,9 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test('throws error if selector matches more than one element', async function(assert) {
+  test('throws error if selector matches more than one element', async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input')
+      foo: attribute('placeholder', ':input'),
     });
 
     await render(hbs`
@@ -98,13 +98,15 @@ module('attribute', function (hooks) {
       <input placeholder="other value">
     `);
 
-    assert.throws(() => page.foo,
-      /matched more than one element. If you want to select many elements, use collections instead./);
+    assert.throws(
+      () => page.foo,
+      /matched more than one element. If you want to select many elements, use collections instead./
+    );
   });
 
-  test('finds element by index', async function(assert) {
+  test('finds element by index', async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input', { at: 1 })
+      foo: attribute('placeholder', ':input', { at: 1 }),
     });
 
     await render(hbs`
@@ -115,9 +117,11 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test('looks for elements outside the testing container', async function(assert) {
+  test('looks for elements outside the testing container', async function (assert) {
     let page = create({
-      foo: attribute('placeholder', ':input', { testContainer: '#alternate-ember-testing' })
+      foo: attribute('placeholder', ':input', {
+        testContainer: '#alternate-ember-testing',
+      }),
     });
 
     await render(hbs``);
@@ -129,10 +133,10 @@ module('attribute', function (hooks) {
     assert.equal(page.foo, 'a value');
   });
 
-  test('normalizes value', async function(assert) {
+  test('normalizes value', async function (assert) {
     let page = create({
       foo: attribute('disabled', 'span'),
-      nonExisting: attribute('non-existing', 'span')
+      nonExisting: attribute('non-existing', 'span'),
     });
 
     await render(hbs`<span disabled></span>`);

--- a/tests/unit/-private/properties/dsl-test.js
+++ b/tests/unit/-private/properties/dsl-test.js
@@ -9,8 +9,7 @@ module('dsl', function (hooks) {
   test('generates .isVisible', async function (assert) {
     let page = create({
       scope: 'span',
-      foo: {
-      }
+      foo: {},
     });
 
     await this.createTemplate('Lorem <span>ipsum</span>');
@@ -19,11 +18,10 @@ module('dsl', function (hooks) {
     assert.ok(page.foo.isVisible, 'component is visible');
   });
 
-  test('generates .isHidden', async function(assert) {
+  test('generates .isHidden', async function (assert) {
     let page = create({
       scope: 'span',
-      foo: {
-      }
+      foo: {},
     });
 
     await this.createTemplate('Lorem <span style="display:none">ipsum</span>');
@@ -32,11 +30,10 @@ module('dsl', function (hooks) {
     assert.ok(page.foo.isHidden, 'component is hidden');
   });
 
-  test('generates .isPresent', async function(assert) {
+  test('generates .isPresent', async function (assert) {
     let page = create({
       scope: 'span',
-      foo: {
-      }
+      foo: {},
     });
 
     await this.createTemplate('Lorem <span>ipsum</span>');
@@ -45,10 +42,23 @@ module('dsl', function (hooks) {
     assert.ok(page.foo.isPresent, 'component is rendered in DOM');
   });
 
-  ['blur', 'click', 'clickOn', 'contains', 'fillIn', 'focus', 'isHidden', 'isPresent', 'isVisible', 'select', 'text', 'value'].forEach((prop) => {
-    test(`does not override .${prop}`, async function(assert) {
+  [
+    'blur',
+    'click',
+    'clickOn',
+    'contains',
+    'fillIn',
+    'focus',
+    'isHidden',
+    'isPresent',
+    'isVisible',
+    'select',
+    'text',
+    'value',
+  ].forEach((prop) => {
+    test(`does not override .${prop}`, async function (assert) {
       let page = create({
-        [prop]: 'foo bar'
+        [prop]: 'foo bar',
       });
 
       await this.createTemplate('');
@@ -57,13 +67,13 @@ module('dsl', function (hooks) {
     });
   });
 
-  test('generates .blur', async function(assert) {
+  test('generates .blur', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'button'
-      }
+        scope: 'button',
+      },
     });
 
     await this.createTemplate('<button>dummy text</button>');
@@ -75,12 +85,11 @@ module('dsl', function (hooks) {
     await page.foo.blur();
   });
 
-  test('generates .clickOn', async function(assert) {
+  test('generates .clickOn', async function (assert) {
     assert.expect(1);
 
     let page = create({
-      foo: {
-      }
+      foo: {},
     });
 
     await this.createTemplate('<button>dummy text</button>');
@@ -92,13 +101,13 @@ module('dsl', function (hooks) {
     await page.foo.clickOn('dummy text');
   });
 
-  test('generates .click', async function(assert) {
+  test('generates .click', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'button'
-      }
+        scope: 'button',
+      },
     });
 
     await this.createTemplate('<button>dummy text</button>');
@@ -108,11 +117,11 @@ module('dsl', function (hooks) {
     await page.foo.click();
   });
 
-  test('generates .contains', async function(assert) {
+  test('generates .contains', async function (assert) {
     let page = create({
       foo: {
-        scope: 'span'
-      }
+        scope: 'span',
+      },
     });
 
     await this.createTemplate('Ipsum <span>Dolor</span>');
@@ -120,12 +129,12 @@ module('dsl', function (hooks) {
     assert.ok(page.foo.contains('or'), 'contains');
   });
 
-  test('generates .text', async function(assert) {
+  test('generates .text', async function (assert) {
     let page = create({
       scope: '.scope',
       foo: {
-        scope: 'span'
-      }
+        scope: 'span',
+      },
     });
 
     await this.createTemplate(`
@@ -137,13 +146,13 @@ module('dsl', function (hooks) {
     assert.equal(page.foo.text, 'Dolor');
   });
 
-  test('generates .fillIn', async function(assert) {
+  test('generates .fillIn', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'input'
-      }
+        scope: 'input',
+      },
     });
 
     await this.createTemplate('<input name="email">');
@@ -153,13 +162,13 @@ module('dsl', function (hooks) {
     assert.equal(find('input').value, 'lorem ipsum');
   });
 
-  test('generates .focus', async function(assert) {
+  test('generates .focus', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'button'
-      }
+        scope: 'button',
+      },
     });
 
     await this.createTemplate('<button>dummy text</button>');
@@ -169,13 +178,13 @@ module('dsl', function (hooks) {
     await page.foo.focus();
   });
 
-  test('generates .select', async function(assert) {
+  test('generates .select', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'input'
-      }
+        scope: 'input',
+      },
     });
 
     await this.createTemplate('<input name="email">');
@@ -185,13 +194,13 @@ module('dsl', function (hooks) {
     assert.equal(find('input').value, 'lorem ipsum');
   });
 
-  test('generates .value', async function(assert) {
+  test('generates .value', async function (assert) {
     assert.expect(1);
 
     let page = create({
       foo: {
-        scope: 'input'
-      }
+        scope: 'input',
+      },
     });
 
     await this.createTemplate('<input value="lorem ipsum">');
@@ -199,62 +208,62 @@ module('dsl', function (hooks) {
     assert.equal(page.foo.value, 'lorem ipsum');
   });
 
-  test('generates .then', async function(assert) {
+  test('generates .then', async function (assert) {
     let page = create({
-      foo: {}
+      foo: {},
     });
 
     await this.createTemplate('');
 
-    assert.ok(typeof (page.then) === 'function');
-    assert.ok(typeof (page.foo.then) === 'function');
+    assert.ok(typeof page.then === 'function');
+    assert.ok(typeof page.foo.then === 'function');
   });
 
-  test('generates .as', async function(assert) {
+  test('generates .as', async function (assert) {
     assert.expect(2);
 
     let page = create({
       scope: 'span',
       foo: {
-        baz: 'foobar'
-      }
+        baz: 'foobar',
+      },
     });
 
     await this.createTemplate('Lorem <span>ipsum</span>');
 
-    let foo = page.foo.as(element => {
+    let foo = page.foo.as((element) => {
       assert.equal(element.text, 'ipsum');
     });
 
     assert.equal(foo.baz, 'foobar');
   });
 
-  test('generates .as when nested', async function(assert) {
+  test('generates .as when nested', async function (assert) {
     assert.expect(1);
 
     let page = create({
       scope: 'span',
       foo: {
         bar: {
-          scope: 'strong'
-        }
-      }
+          scope: 'strong',
+        },
+      },
     });
 
     await this.createTemplate(
       'Lorem <span>ipsum <strong>dolor</strong></span>'
     );
 
-    page.foo.bar.as(element => {
+    page.foo.bar.as((element) => {
       assert.equal(element.text, 'dolor');
     });
   });
 
-  test('generates .as in collections', async function(assert) {
+  test('generates .as in collections', async function (assert) {
     assert.expect(2);
 
     let page = create({
-      items: collection('ul li')
+      items: collection('ul li'),
     });
 
     await this.createTemplate(`
@@ -264,11 +273,11 @@ module('dsl', function (hooks) {
       </ul>
     `);
 
-    page.items[0].as(item => {
+    page.items[0].as((item) => {
       assert.equal(item.text, 'foo');
     });
 
-    page.items[1].as(item => {
+    page.items[1].as((item) => {
       assert.equal(item.text, 'bar');
     });
   });

--- a/tests/unit/addon-exports-test.js
+++ b/tests/unit/addon-exports-test.js
@@ -26,57 +26,71 @@ const EXPECTED_METHODS = [
   'selectable',
   'text',
   'value',
-  'visitable'
+  'visitable',
 ];
 
 const HELPER_METHODS = [
   'buildSelector',
   'findElement',
-  'findElementWithAssert'
+  'findElementWithAssert',
 ];
 
-const EXTEND_METHODS = HELPER_METHODS.concat([
-  'findOne',
-  'findMany'
-]);
+const EXTEND_METHODS = HELPER_METHODS.concat(['findOne', 'findMany']);
 
-const EXPECTED_MACROS = [
-  'alias',
-  'getter'
-];
+const EXPECTED_MACROS = ['alias', 'getter'];
 
 EXPECTED_METHODS.forEach((method) => {
-  test(`imports PageObject.${ method } from addon`, function(assert) {
-    assert.equal(typeof (Addon['default'][method]), 'function', `Imports PageObject.${method}`);
+  test(`imports PageObject.${method} from addon`, function (assert) {
+    assert.equal(
+      typeof Addon['default'][method],
+      'function',
+      `Imports PageObject.${method}`
+    );
   });
 });
 
 EXPECTED_METHODS.concat(HELPER_METHODS).forEach((method) => {
-  test(`imports { ${method } } from addon`, function(assert) {
-    assert.equal(typeof (Addon[method]), 'function', `Imports PageObject.${method}`);
+  test(`imports { ${method} } from addon`, function (assert) {
+    assert.equal(
+      typeof Addon[method],
+      'function',
+      `Imports PageObject.${method}`
+    );
   });
 });
 
 EXPECTED_METHODS.forEach((method) => {
-  test(`imports PageObject.${ method } from test-support`, function(assert) {
-    assert.equal(typeof (TestSupport['default'][method]), 'function', `Imports PageObject.${method}`);
+  test(`imports PageObject.${method} from test-support`, function (assert) {
+    assert.equal(
+      typeof TestSupport['default'][method],
+      'function',
+      `Imports PageObject.${method}`
+    );
   });
 });
 
 EXPECTED_METHODS.concat(HELPER_METHODS).forEach((method) => {
-  test(`imports { ${method } } from test-support`, function(assert) {
-    assert.equal(typeof (TestSupport[method]), 'function', `Imports PageObject.${method}`);
+  test(`imports { ${method} } from test-support`, function (assert) {
+    assert.equal(
+      typeof TestSupport[method],
+      'function',
+      `Imports PageObject.${method}`
+    );
   });
 });
 
 EXTEND_METHODS.forEach((method) => {
-  test(`imports { ${method } } from extend folder`, function(assert) {
-    assert.equal(typeof (Extend['default'][method]), 'function', `Imports ${method}`);
+  test(`imports { ${method} } from extend folder`, function (assert) {
+    assert.equal(
+      typeof Extend['default'][method],
+      'function',
+      `Imports ${method}`
+    );
   });
 });
 
 EXPECTED_MACROS.forEach((method) => {
-  test(`imports { ${method } } from macros`, function(assert) {
-    assert.equal(typeof (Macros[method]), 'function', `Imports ${method} macro`);
+  test(`imports { ${method} } from macros`, function (assert) {
+    assert.equal(typeof Macros[method], 'function', `Imports ${method} macro`);
   });
 });


### PR DESCRIPTION
Prettier is now the default in Ember CLI projects so I ran `lint:fix:js` to cleanup all the javascript to that standard. 
I chose to ignore all the Ember Octane listing rules in the dummy at at this point because there is already a lot going on here and those shouldn't cause any problems for a while and can be modified later.
This left a few specific listing issues that I fixed individually.